### PR TITLE
fix: infer the Load Balancer VPC using the subnet, remove…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ module "ecs_cluster" {
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.0 |
 ## Providers
 
@@ -96,6 +95,7 @@ module "ecs_cluster" {
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_lb.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_subnet.lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -131,7 +131,6 @@ module "ecs_cluster" {
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for the Load Balancer. The Load Balancer will be created in the VPC associated with the subnet IDs. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC. Required if `alb_enabled` is `true`. | `string` | `null` | no |
 ## Outputs
 
 | Name | Description |

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "ecs_cluster_container_insights_enabled" {
   description = "Whether or not Container Insights should be enabled."
 }
 
-variable "vpc_id" {
-  type        = string
-  default     = null
-  description = "ID of the VPC. Required if `alb_enabled` is `true`."
-}
-
 variable "subnet_ids" {
   type        = list(string)
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
+      source                = "hashicorp/aws"
+      version               = ">= 3.0"
+      configuration_aliases = [aws.route53]
     }
     local = {
       source  = "hashicorp/local"
@@ -17,10 +18,6 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = ">= 3.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
… the hashicorp/template provider

GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [X] Other, please describe: removed unused/unwanted dependency in providers

## What is the new behavior?

The module will infer the VPC id from the subnet to configure the load balancer. Also, the `hashicorp/template` provider will not longer be required as a dependency.

## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [X] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

