### PR TITLE
fix: bump of nventive/lb/aws module for the creating of ACL on access…

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ module "ecs_cluster" {
 |------|--------|---------|
 | <a name="module_alb_dns_alias"></a> [alb\_dns\_alias](#module\_alb\_dns\_alias) | cloudposse/route53-alias/aws | 0.13.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.0.0 |
+| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.0.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ data "aws_subnet" "lb" {
 
 module "lb" {
   source  = "nventive/lb/aws"
-  version = "1.0.0"
+  version = "1.0.1"
   enabled = local.alb_enabled && local.enabled
 
   subnet_ids                = var.subnet_ids


### PR DESCRIPTION
fix: bump of nventive/lb/aws module for the creating of ACL on access log bucket


## Proposed Changes

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?

Module is unable to apply a plan for the ACL on the access logs bucket.


## What is the new behavior?
Module will be able to apply a plan for the ACL on the access logs bucket.


## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

