### PR TITLE
feat: Make ALB `attribute` configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ module "ecs_cluster" {
 |------|--------|---------|
 | <a name="module_alb_dns_alias"></a> [alb\_dns\_alias](#module\_alb\_dns\_alias) | cloudposse/route53-alias/aws | 0.13.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.0.1 |
+| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 ## Resources
 
@@ -107,6 +107,7 @@ module "ecs_cluster" {
 | <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | Set if you want to use an existing Application Load Balancer. | `string` | `""` | no |
 | <a name="input_alb_dns_aliases"></a> [alb\_dns\_aliases](#input\_alb\_dns\_aliases) | List of custom domain name aliases for ALB. | `list(string)` | `[]` | no |
 | <a name="input_alb_enabled"></a> [alb\_enabled](#input\_alb\_enabled) | Set to false to prevent the module from creating an Application Load Balancer.<br>This setting defaults to false if `alb_arn` is specified. | `bool` | `true` | no |
+| <a name="input_alb_internal"></a> [alb\_internal](#input\_alb\_internal) | Set to `true` to make the ALB internal. | `bool` | `false` | no |
 | <a name="input_alb_ip_address_type"></a> [alb\_ip\_address\_type](#input\_alb\_ip\_address\_type) | Address type for ALB possible. Specify one of `ipv4`, `dualstack`. Only when `alb_enabled = true`. | `string` | `null` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain Cloudwatch logs. | `number` | `60` | no |

--- a/main.tf
+++ b/main.tf
@@ -98,11 +98,12 @@ data "aws_subnet" "lb" {
 
 module "lb" {
   source  = "nventive/lb/aws"
-  version = "1.0.1"
+  version = "1.1.0"
   enabled = local.alb_enabled && local.enabled
 
   subnet_ids                = var.subnet_ids
   ip_address_type           = var.alb_ip_address_type
+  internal                  = var.alb_internal
   load_balancer_type        = "application"
   enable_http2              = true
   security_group_enabled    = true

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "alb_arn" {
   description = "Set if you want to use an existing Application Load Balancer."
 }
 
+variable "alb_internal" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to make the ALB internal."
+}
+
 variable "alb_ip_address_type" {
   type        = string
   default     = null


### PR DESCRIPTION
GitHub Issue:  N/A

## Proposed Changes

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?

The `internal` attribute of the Load Balancer is not configurable.

## What is the new behavior?

The `internal` attribute of the Load Balancer is configurable with a variable that defaults to `false`.

## Checklist

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

N/A

