### PR TITLE
chore: bump the version of the module nventive/lb/aws to 1.2.0 for th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ module "ecs_cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.21.0 |
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alb_dns_alias"></a> [alb\_dns\_alias](#module\_alb\_dns\_alias) | cloudposse/route53-alias/aws | 0.13.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.1.0 |
+| <a name="module_lb"></a> [lb](#module\_lb) | nventive/lb/aws | 1.2.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ data "aws_subnet" "lb" {
 
 module "lb" {
   source  = "nventive/lb/aws"
-  version = "1.1.0"
+  version = "1.2.0"
   enabled = local.alb_enabled && local.enabled
 
   subnet_ids                = var.subnet_ids


### PR DESCRIPTION
…the feat of more specific SG names on the ECS cluster ALB

## Proposed Changes
Bump the version of the module nventive/lb/aws to 1.2.0 for the feat of more specific SG names on the ECS cluster ALB

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [X] Other, please describe: chore

## What is the current behavior?
The ECS cluster ALB SG name wasn't specific.


## What is the new behavior?
The ECS cluster ALB SG name is specific.

## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
