### PR TITLE
fix: Fix bug with data.aws_subnet.lb being used even when count is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module "ecs_cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
 ## Modules
 
 | Name | Source | Version |

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ module "lb" {
   access_logs_enabled       = var.alb_access_logs_enabled
   access_logs_force_destroy = var.alb_access_logs_force_destroy
   access_logs_prefix        = var.alb_access_logs_prefix
-  vpc_id                    = data.aws_subnet.lb.0.vpc_id
+  vpc_id                    = join("", data.aws_subnet.lb.*.vpc_id)
 
   context = module.this.context
 }


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

This corrects a bug that happens when `local.alb_enabled` computes to `false`.

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?

If `local.alb_enabled` computes to `false` Terraform crashes because it's still using the `data.aws_subnet.lb.0.vpc_id` to pass it to the module, even if the module itself has `enabled = false`.

AKA: It happens before it gets to the submodule.

## What is the new behavior?

When `local.alb_enabled` computes to `false`, an empty string is passed to the `vpc_id` input of the `lb` module.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a