### PR TITLE
fix: Update validation for aliases parent zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ module "alb_dns_alias" {
 resource "null_resource" "aliases_parent_zone_validation" {
   lifecycle {
     precondition {
-      condition     = local.alb_alias_enabled && var.parent_zone_id == null && var.parent_zone_id == null
+      condition     = local.alb_alias_enabled && !(var.parent_zone_id == null && var.parent_zone_name == null)
       error_message = "When using `alb_dns_aliases` you should specify either `parent_zone_id` or `parent_zone_name`."
     }
   }


### PR DESCRIPTION
## Proposed Changes

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?
There was a bug in the validation of the parent zone. It would only work when you used the parent zone name, not the zone id.

## What is the new behavior?
Now, you can specify either the zone id or the zone name.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] ~Documentation has been added/updated.~
- [ ] ~Automated tests for the changes have been added/updated.~
- [x] Commits have been squashed (if applicable).
- [ ] ~Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).~
